### PR TITLE
Change the log level from info to debug

### DIFF
--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -215,7 +215,7 @@ module Kafka
     rescue NoPartitionsToFetchFrom
       backoff = @max_wait_time > 0 ? @max_wait_time : 1
 
-      @logger.info "There are no partitions to fetch from, sleeping for #{backoff}s"
+      @logger.debug "There are no partitions to fetch from, sleeping for #{backoff}s"
       sleep backoff
 
       []


### PR DESCRIPTION
In order to avoid the multiple logs that are logged when the info level is used (usually on production) we introduce a new change to the fetch_batches log from info to debug.